### PR TITLE
Fix getModerator

### DIFF
--- a/api.js
+++ b/api.js
@@ -108,6 +108,7 @@ utopian.getModerator = (username) => {
           resolve(moderator)
         }
       })
+      resolve([])
     }).catch((err) => reject(err))
   })
 }


### PR DESCRIPTION
Returns empty array if the username is not of moderator.