### PR TITLE
Fix getsponsor

### DIFF
--- a/api.js
+++ b/api.js
@@ -123,9 +123,10 @@ utopian.getSponsor = (username) => {
     utopian.getSponsors().then((sponsors) => {
       sponsors.results.filter((sponsor) => {
         if (sponsor.account === username) {
-          resolve(sponsor)
+          resolve([sponsor])
         }
       })
+      resolve([])
     }).catch((err) => reject(err))
   })
 }


### PR DESCRIPTION
Reflects the documentation of the function.

`getSponsor(username) : returns array with informations if username is an utopian sponsor otherwise the array is empty`