### PR TITLE
Fix getPosts check for default values

### DIFF
--- a/api.js
+++ b/api.js
@@ -214,11 +214,10 @@ utopian.getPostURL = (postID) => {
 utopian.getPostByAuthor = (username, options) => {
   return new Promise((resolve, reject) => {
     if (!options) options = {}
-    if (options.limit > 20 || options.limit < 1) {
-      options.limit = 20
+    if (!options.limit || options.limit < 1 || options.limit > 50) {
+      options.limit = 50
     }
-    if (options.length === 0) {
-      options.limit = 20
+    if (!options.skip || options.skip < 0) {
       options.skip = 0
     }
     options.section = 'author'

--- a/api.js
+++ b/api.js
@@ -138,8 +138,8 @@ utopian.getSponsor = (username) => {
 utopian.getPosts = (options) => {
   if (!options) options = {}
 
-  if (!options.limit || options.limit < 1) {
-    options.limit = 20
+  if (!options.limit || options.limit < 1 || options.limit > 50) {
+    options.limit = 50
   }
 
   if (!options.skip || options.skip < 0) {

--- a/api.js
+++ b/api.js
@@ -138,12 +138,11 @@ utopian.getSponsor = (username) => {
 utopian.getPosts = (options) => {
   if (!options) options = {}
 
-  if (options.limit > 20 || options.limit < 1) {
+  if (!options.limit || options.limit < 1) {
     options.limit = 20
   }
 
-  if (options.length === 0) {
-    options.limit = 20
+  if (!options.skip || options.skip < 0) {
     options.skip = 0
   }
 


### PR DESCRIPTION
1. Checks only the minimum for *limit*
2. options.length would return false unless the caller set the parameter explicitly to 0. The API does not have *length* parameter so it would be unused anyway. There is now only simple test for minimum *skip*