### PR TITLE
getPostByAuthor default options values check

### DIFF
--- a/api.js
+++ b/api.js
@@ -215,11 +215,10 @@ utopian.getPostURL = (postID) => {
 utopian.getPostByAuthor = (username, options) => {
   return new Promise((resolve, reject) => {
     if (!options) options = {}
-    if (options.limit > 20 || options.limit < 1) {
+    if (!options.limit || options.limit < 1) {
       options.limit = 20
     }
-    if (options.length === 0) {
-      options.limit = 20
+    if (!options.skip || options.skip < 0) {
       options.skip = 0
     }
     options.section = 'author'


### PR DESCRIPTION
- Checks only the minimum limit
- options.length would return false unless the caller set the parameter explicitly to 0. The API does not have length parameter so it would be unused anyway. There is now only simple check for minimum skip